### PR TITLE
Add support for iPhone XR, XS and XS Max

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export function isIphoneX() {
         Platform.OS === 'ios' &&
         !Platform.isPad &&
         !Platform.isTVOS &&
-        (dimen.height === 812 || dimen.width === 812)
+        ((dimen.height === 812 || dimen.width === 812) || (dimen.height === 896 || dimen.width === 896))
     );
 }
 


### PR DESCRIPTION
iPhone XR:
{"fontScale":1,"width":414,"height":896,"scale":2}

iPhone XS:
{"fontScale":1,"width":414,"height":896,"scale":2}

iPhone XS Max:
{"fontScale":1,"width":414,"height":896,"scale":3}