### PR TITLE
feat: add support for iPhone 12 and 13 screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ if (isIphoneX()) {
 #### Parameters ####
 **safe** - whether you want for get safe area height or not
 
-**returns** - the height of the status bar: `44` for safe iPhoneX, `30` for unsafe iPhoneX, `20` for other iOS devices and `StatusBar.currentHeight` for Android.
+**returns** - the height of the status bar:
+`50` for safe iPhone 12 Mini and 13 Mini
+`47` for safe others iPhone 12 and 13
+`44` for safe iPhone X
+`30` for unsafe iPhone X
+`20` for other iOS devices
+`StatusBar.currentHeight` for Android.
 
 #### Example ####
 

--- a/index.js
+++ b/index.js
@@ -7,12 +7,26 @@ export function isIphoneX() {
         !Platform.isPad &&
         !Platform.isTVOS &&
         ((dimen.height === 780 || dimen.width === 780)
-          || (dimen.height === 812 || dimen.width === 812)
-          || (dimen.height === 844 || dimen.width === 844)
-          || (dimen.height === 896 || dimen.width === 896)
-          || (dimen.height === 926 || dimen.width === 926))
+            || (dimen.height === 812 || dimen.width === 812)
+            || (dimen.height === 844 || dimen.width === 844)
+            || (dimen.height === 896 || dimen.width === 896)
+            || (dimen.height === 926 || dimen.width === 926))
     );
 }
+
+const checkDimensions = (portraitWidth, portraitHeight) => {
+    const dimen = Dimensions.get('window');
+
+    return (dimen.height === portraitHeight && dimen.width === portraitWidth)
+        || (dimen.width === portraitHeight && dimen.height === portraitWidth)
+}
+
+// 5.4: 12 Mini, 13 Mini
+const isIphoneScreen54 = () => checkDimensions(375, 812)
+// 6.1: 12, 12 Pro, 13, 13 Pro
+const isIphoneScreen61 = () => checkDimensions(390, 844)
+// 6.7: 12 Pro Max, 13 Pro Max
+const isIphoneScreen67 = () => checkDimensions(428, 926)
 
 export function ifIphoneX(iphoneXStyle, regularStyle) {
     if (isIphoneX()) {
@@ -21,9 +35,27 @@ export function ifIphoneX(iphoneXStyle, regularStyle) {
     return regularStyle;
 }
 
+function getIphoneStatusBarHeight(safe) {
+    if (isIphoneX()) {
+        if (!safe) {
+            return 30
+        }
+        if (isIphoneScreen54()) {
+            return 50
+        }
+        if (isIphoneScreen61() || isIphoneScreen67()) {
+            return 47
+        }
+
+        return 44
+    }
+
+    return 20
+}
+
 export function getStatusBarHeight(safe) {
     return Platform.select({
-        ios: ifIphoneX(safe ? 44 : 30, 20),
+        ios: getIphoneStatusBarHeight(safe),
         android: StatusBar.currentHeight,
         default: 0
     });


### PR DESCRIPTION
fixes #33

Add safe area top height support for iPhone 12 and 13 screens

Based on Apples screen dimensions and safe area standardisation https://useyourloaf.com/blog/iphone-13-screen-sizes/