### PR TITLE
Support iPhone12, 12 Pro, 12 Pro Max, 12 Mini, 13, 13 Pro, 13 Pro Max, 13 Mini, 14, 14 Plus, 14 Pro, 14 Pro Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ if (isIphoneX()) {
 | 47 | iPhone12, 12 Pro, 12 Pro Max, 13, 13 Pro, 13 Pro Max, 14, 14 Plus |
 | 48(Not Supported Now) | iPhone11, Xr |
 | 50 | iPhone12 Mini, 13 Mini |
-| 54 | iPhone14 Pro、14 Pro Max |
+| 59 | iPhone14 Pro、14 Pro Max |
 
 
 #### Example ####

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 A library to help you design your react-native app for notched iPhones.
 
 ## Installing ##
+`yarn add react-native-iphone-x-helper`
+
+or
+
 `npm i react-native-iphone-x-helper --save`
 
 ## API ##
@@ -58,12 +62,23 @@ if (isIphoneX()) {
 }
 ```
 
-### getStatusBarHeight([safe]) ###
+### getStatusBarHeight() ###
 
 #### Parameters ####
-**safe** - whether you want for get safe area height or not
+**returns** 
++ Android: `StatusBar.currentHeight`
++ iOS:
 
-**returns** - the height of the status bar: `44` for safe iPhoneX, `30` for unsafe iPhoneX, `20` for other iOS devices and `StatusBar.currentHeight` for Android.
+
+| StatusBarHeight | Devices | 
+| -- | -- |
+| 20 | Others |
+| 44 | iPhoneX, Xs, Xs Max, 11 Pro, 11 Pro Max |
+| 47 | iPhone12, 12 Pro, 12 Pro Max, 13, 13 Pro, 13 Pro Max, 14, 14 Plus |
+| 48(Not Supported Now) | iPhone11, Xr |
+| 50 | iPhone12 Mini, 13 Mini |
+| 54 | iPhone14 Pro、14 Pro Max |
+
 
 #### Example ####
 
@@ -108,6 +123,23 @@ export default StyleSheet.create({
         marginBottom: getBottomSpace()
     },
 });
+```
+
+### isDynamicIsland ###
+
+**returns** the device whether contains the dynamic island. Specifically, 14 Pro 和 14 Pro Max by now
+
+#### Example ####
+```js
+import { isDynamicIsland } from 'react-native-iphone-x-helper'
+
+// ...
+
+if (isDynamicIsland()) {
+    // do this...
+} else {
+    // do that...
+}
 ```
 
 ## Licence ##

--- a/index.js
+++ b/index.js
@@ -1,34 +1,106 @@
-import { Dimensions, Platform, StatusBar } from 'react-native';
+/** @format */
+
+import { Dimensions, Platform, StatusBar } from "react-native"
 
 export function isIphoneX() {
-    const dimen = Dimensions.get('window');
     return (
-        Platform.OS === 'ios' &&
+        Platform.OS === "ios" &&
         !Platform.isPad &&
         !Platform.isTVOS &&
-        ((dimen.height === 780 || dimen.width === 780)
-          || (dimen.height === 812 || dimen.width === 812)
-          || (dimen.height === 844 || dimen.width === 844)
-          || (dimen.height === 896 || dimen.width === 896)
-          || (dimen.height === 926 || dimen.width === 926))
-    );
+        (checkDemension(780) ||
+            checkDemension(812) ||
+            checkDemension(844) ||
+            checkDemension(896) ||
+            checkDemension(926) ||
+            checkDemension(852) ||
+            checkDemension(932))
+    )
+}
+
+export function isDynamicIsland() {
+    return Platform.OS === "ios" && !Platform.isPad && !Platform.isTVOS && _isStatusBarHeight59()
+}
+
+const checkDemension = (size) => {
+    const window = Dimensions.get("window")
+    const windowRes = window.width == size || window.height == size
+    const screen = Dimensions.get("screen")
+    const screenRes = screen.width == size || screen.height == size
+    return windowRes || screenRes
+}
+
+const checkDimensions = (portraitWidth, portraitHeight) => {
+    const window = Dimensions.get("window")
+    const windowRes =
+        (window.height === portraitHeight && window.width === portraitWidth) ||
+        (window.width === portraitHeight && window.height === portraitWidth)
+
+    const screen = Dimensions.get("screen")
+    const screenRes =
+        (screen.height === portraitHeight && screen.width === portraitWidth) ||
+        (screen.width === portraitHeight && screen.height === portraitWidth)
+
+    return windowRes || screenRes
+}
+
+// 12, 12 Pro, 13, 13 Pro and 12 Pro Max, 13 Pro Max
+const _isStatusBarHeight47 = () => {
+    return checkDimensions(390, 844) || checkDimensions(428, 926)
+}
+
+// 11, xr
+const _isStatusBarHeight48 = () => {
+    // FIXME: cannot distinguish 11/xr between 11/11 pro max by their resolution
+    // if (!checkDimensions(414, 896)) {
+    //     return false
+    // }
+    return false
+}
+
+// 12 Mini, 13 Mini
+const _isStatusBarHeight50 = () => {
+    return checkDimensions(360, 780)
+}
+// 14 Pro, 14 Pro Max
+const _isStatusBarHeight59 = () => {
+    return checkDimensions(393, 852) || checkDimensions(430, 932)
+}
+
+const _getIphoneStatusBarHeight = () => {
+    if (isIphoneX()) {
+        if (_isStatusBarHeight47()) {
+            return 47
+        }
+        if (_isStatusBarHeight48()) {
+            return 48
+        }
+        if (_isStatusBarHeight50()) {
+            return 50
+        }
+        if (_isStatusBarHeight59()) {
+            return 59
+        }
+        return 44
+    }
+
+    return 20
 }
 
 export function ifIphoneX(iphoneXStyle, regularStyle) {
     if (isIphoneX()) {
-        return iphoneXStyle;
+        return iphoneXStyle
     }
-    return regularStyle;
+    return regularStyle
 }
 
-export function getStatusBarHeight(safe) {
+export function getStatusBarHeight() {
     return Platform.select({
-        ios: ifIphoneX(safe ? 44 : 30, 20),
+        ios: _getIphoneStatusBarHeight(),
         android: StatusBar.currentHeight,
-        default: 0
-    });
+        default: 0,
+    })
 }
 
 export function getBottomSpace() {
-    return isIphoneX() ? 34 : 0;
+    return isIphoneX() ? 34 : 0
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ export function isDynamicIsland() {
 }
 
 const checkDemension = (size) => {
+    // window is not correct sometimes when screen is correct
     const window = Dimensions.get("window")
     const windowRes = window.width == size || window.height == size
     const screen = Dimensions.get("screen")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iphone-x-helper",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A library to help you design your react-native app for the iPhone X",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iphone-x-helper",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "A library to help you design your react-native app for the iPhone X",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Feat: Support All Devices except iPhone11 & iPhone Xr

| StatusBarHeight | Devices | 
| -- | -- |
| 20 | Others |
| 44 | iPhoneX, Xs, Xs Max, 11 Pro, 11 Pro Max |
| 47 | iPhone12, 12 Pro, 12 Pro Max, 13, 13 Pro, 13 Pro Max, 14, 14 Plus |
| 48(Not Supported Now) | iPhone11, Xr |
| 50 | iPhone12 Mini, 13 Mini |
| 59 | iPhone14 Pro、14 Pro Max |

## Fix: `Dimensions.get("window")` 's width & height is not correct sometimes when `Dimensions.get("srceen")` is correct

## Feat: remove `getStatusBarHeight` param `safe`，which is useless in actual use

